### PR TITLE
Update scene_insteon.py

### DIFF
--- a/isy994/items/scenes/scene_insteon.py
+++ b/isy994/items/scenes/scene_insteon.py
@@ -35,10 +35,10 @@ class Scene_Insteon(Scene_Base):
         for address in self.responders:
             device = self.container.get_device(address)
             if device is not None:
-                if device.category == "1":  # insteon dimmer
+                if device.device_type == "dimmer":  # insteon dimmer
                     if device.get_property("level") > 0:
                         scene_onoff = "on"
-                if device.category == "2":  # insteon switch
+                if device.device_type == "switch":  # insteon switch
                     if device.get_property("onoff") == "on":
                         scene_onoff = "on"
 


### PR DESCRIPTION
Fixes error when fanlincs are present:
container manager Error 'level'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/isy994/items/scenes/scene_container.py", line 31, in start
    self.process_scene_nodes(root)
  File "/usr/local/lib/python3.7/dist-packages/isy994/items/scenes/scene_container.py", line 43, in process_scene_nodes
    self.process_scene_node(scene)
  File "/usr/local/lib/python3.7/dist-packages/isy994/items/scenes/scene_container.py", line 54, in process_scene_node
    scene.update_onoff()
  File "/usr/local/lib/python3.7/dist-packages/isy994/items/scenes/scene_insteon.py", line 40, in update_onoff
    if device.get_property("level") > 0:
  File "/usr/local/lib/python3.7/dist-packages/isy994/items/item_base.py", line 45, in get_property
    return self.properties[property_]
KeyError: 'level'